### PR TITLE
Travis rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: ruby
 rvm:
-  - 1.9.3
+- 1.9.3
 before_install: gem install bundler
 script:
-  - bundle exec rspec --no-drb --format progress spec/
+- bundle exec rspec --no-drb --format progress spec/
+deploy:
+  provider: rubygems
+  api_key:
+    secure: IiMz64fFryLhw23uEv2GlluTufOnO+PGJqeqx7aqvHZO2bThpiLxP7Dv7I9QN5u6546/BiWEPum9+mh5t8FfIVR5dKus65EzZs+gqvB4mUBKDCx7soaTRJ6dshrHrV+vEgwZyWk07HuXA/IlcTx/qNHzQXeTsCXlt66DJZDL5is=
+  gem: guard-zeus
+  on:
+    repo: qnm/guard-zeus

--- a/guard-zeus.gemspec
+++ b/guard-zeus.gemspec
@@ -4,6 +4,7 @@ require File.expand_path('../lib/guard/zeus/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.name          = "guard-zeus"
   gem.version       = Guard::ZeusVersion::VERSION
+  gem.version       = "#{gem.version}-alpha-#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
   gem.platform      = Gem::Platform::RUBY
   gem.authors       = ["jonathangreenberg", "Andrew Assarattanakul", "Rob Sharp"]
   gem.email         = ["greenberg@entryway.net", "assarata@gmail.com", "qnm@fea.st"]


### PR DESCRIPTION
Using [the guide](http://docs.travis-ci.com/user/deployment/rubygems/), configure travis-ci to deploy pre-release versions of the gem on a successful build.
