### PR TITLE
Get versioning in-line with guard

### DIFF
--- a/lib/guard/zeus/version.rb
+++ b/lib/guard/zeus/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module ZeusVersion
-    VERSION = "0.0.1"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
Enough folks are using this gem (successfully?) that I feel I can now move the versioning in-line with guard's own version.
