### PR TITLE
Remove the version lock on libnotify to allow it to upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ if RbConfig::CONFIG['target_os'] =~ /darwin/i
   gem 'growl', :require => false
 end
 if RbConfig::CONFIG['target_os'] =~ /linux/i
-  gem 'libnotify', '~> 0.7.1', :require => false
+  gem 'libnotify', :require => false
 end


### PR DESCRIPTION
VersionEye noted that I had an outdated libnotify, so I'm removing the Gem versioning to allow it upgrade.
