### PR TITLE
Upgrade rspec to 3.0.0

### DIFF
--- a/guard-zeus.gemspec
+++ b/guard-zeus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'zeus', '~> 0'
 
   gem.add_development_dependency 'bundler', '~> 1.0'
-  gem.add_development_dependency 'rspec', '~> 2.14'
+  gem.add_development_dependency 'rspec', '~> 3.0.0'
 
   gem.files         = Dir.glob('{lib}/**/*') + %w[LICENSE README.md]
   gem.require_path  = 'lib'

--- a/spec/guard/zeus/runner_spec.rb
+++ b/spec/guard/zeus/runner_spec.rb
@@ -8,12 +8,12 @@ describe Guard::Zeus::Runner do
     subject { runner.options }
 
     context 'with default options' do
-      it { should == {:run_all => true} }
+      it { is_expected.to eq({:run_all => true}) }
     end
 
     context 'with run_all => false' do
       let(:runner) { Guard::Zeus::Runner.new :run_all => false }
-      it { should == {:run_all => false} }
+      it { is_expected.to eq({:run_all => false}) }
     end
   end
 
@@ -22,55 +22,55 @@ describe Guard::Zeus::Runner do
       subject { Guard::Zeus::Runner.new :cli => '--time' }
 
       before do
-        subject.stub(test_unit?: false, rspec?: true, bundler?: false)
+        allow(subject).to receive_messages(test_unit?: false, rspec?: true, bundler?: false)
       end
 
       it "launches zeus start with cli options" do
-        subject.should_receive(:spawn_zeus).with("zeus start", "--time")
+        expect(subject).to receive(:spawn_zeus).with("zeus start", "--time")
         subject.launch_zeus('Start')
       end
     end
 
     context 'with Test::Unit only' do
       before do
-        subject.stub(test_unit?: true, rspec?: false, bundler?: false)
+        allow(subject).to receive_messages(test_unit?: true, rspec?: false, bundler?: false)
       end
 
       it "launches zeus start for Test::Unit" do
-        subject.should_receive(:spawn_zeus).with("zeus start", "")
+        expect(subject).to receive(:spawn_zeus).with("zeus start", "")
         subject.launch_zeus('Start')
       end
     end
 
     context 'with Test::Unit and Bundler' do
       before do
-        subject.stub(test_unit?: true, rspec?: false, bundler?: true)
+        allow(subject).to receive_messages(test_unit?: true, rspec?: false, bundler?: true)
       end
 
       it "launches zeus start for Test::Unit with 'bundle exec'" do
-        subject.should_receive(:spawn_zeus).with("bundle exec zeus start", "")
+        expect(subject).to receive(:spawn_zeus).with("bundle exec zeus start", "")
         subject.launch_zeus('Start')
       end
     end
 
     context 'with RSpec only' do
       before do
-        subject.stub(test_unit?: false, rspec?: true, bundler?: false)
+        allow(subject).to receive_messages(test_unit?: false, rspec?: true, bundler?: false)
       end
 
       it "launches zeus start for RSpec" do
-        subject.should_receive(:spawn_zeus).with("zeus start", "")
+        expect(subject).to receive(:spawn_zeus).with("zeus start", "")
         subject.launch_zeus('Start')
       end
     end
 
     context 'with Rspec and Bundler' do
       before do
-        subject.stub(test_unit?: false, rspec?: true, bundler?: true)
+        allow(subject).to receive_messages(test_unit?: false, rspec?: true, bundler?: true)
       end
 
       it "launches zeus start for RSpec with 'bundle exec'" do
-        subject.should_receive(:spawn_zeus).with("bundle exec zeus start", "")
+        expect(subject).to receive(:spawn_zeus).with("bundle exec zeus start", "")
         subject.launch_zeus('Start')
       end
     end
@@ -78,52 +78,52 @@ describe Guard::Zeus::Runner do
 
   describe '.kill_zeus' do
     it 'not call Process#kill with no zeus_id' do
-      Process.should_not_receive(:kill)
+      expect(Process).not_to receive(:kill)
       subject.kill_zeus
     end
 
     it "calls Process#kill with 'INT, pid'" do
-      subject.should_receive(:fork).and_return(123)
+      expect(subject).to receive(:fork).and_return(123)
       subject.send(:spawn_zeus, '')
 
-      Process.should_receive(:kill).with(:INT, 123)
-      Process.should_receive(:waitpid).with(123, Process::WNOHANG).and_return(123)
-      Process.should_not_receive(:kill).with(:KILL, 123)
+      expect(Process).to receive(:kill).with(:INT, 123)
+      expect(Process).to receive(:waitpid).with(123, Process::WNOHANG).and_return(123)
+      expect(Process).not_to receive(:kill).with(:KILL, 123)
       subject.kill_zeus
     end
 
     it "calls Process#kill with 'KILL, pid' if Process.waitpid returns nil" do
-      subject.should_receive(:fork).and_return(123)
+      expect(subject).to receive(:fork).and_return(123)
       subject.send(:spawn_zeus, '')
 
-      Process.should_receive(:kill).with(:INT, 123)
-      Process.should_receive(:waitpid).with(123, Process::WNOHANG).and_return(nil)
-      Process.should_receive(:kill).with(:KILL, 123)
+      expect(Process).to receive(:kill).with(:INT, 123)
+      expect(Process).to receive(:waitpid).with(123, Process::WNOHANG).and_return(nil)
+      expect(Process).to receive(:kill).with(:KILL, 123)
       subject.kill_zeus
     end
 
     it 'calls rescue when Process.waitpid raises Errno::ECHILD' do
-      subject.should_receive(:fork).and_return(123)
+      expect(subject).to receive(:fork).and_return(123)
       subject.send(:spawn_zeus, '')
 
-      Process.should_receive(:kill).with(:INT, 123)
-      Process.should_receive(:waitpid).with(123, Process::WNOHANG).and_raise(Errno::ECHILD)
-      Process.should_not_receive(:kill).with(:KILL, 123)
+      expect(Process).to receive(:kill).with(:INT, 123)
+      expect(Process).to receive(:waitpid).with(123, Process::WNOHANG).and_raise(Errno::ECHILD)
+      expect(Process).not_to receive(:kill).with(:KILL, 123)
       subject.kill_zeus
     end
 
     it "deletes the zeus socket file while stopping" do
       socket_file = subject.send(:sockfile)
       FileUtils.touch(socket_file)
-      subject.should_receive(:fork).and_return(123)
+      expect(subject).to receive(:fork).and_return(123)
       subject.send(:spawn_zeus, '')
-      expect(File.exist?(socket_file)).to be_true
+      expect(File.exist?(socket_file)).to be_truthy
 
-      Process.should_receive(:kill).with(:INT, 123)
-      Process.should_receive(:waitpid).with(123, Process::WNOHANG).and_raise(Errno::ECHILD)
-      Process.should_not_receive(:kill).with(:KILL, 123)
+      expect(Process).to receive(:kill).with(:INT, 123)
+      expect(Process).to receive(:waitpid).with(123, Process::WNOHANG).and_raise(Errno::ECHILD)
+      expect(Process).not_to receive(:kill).with(:KILL, 123)
       subject.kill_zeus
-      expect(File.exist?(socket_file)).not_to be_true
+      expect(File.exist?(socket_file)).not_to be_truthy
     end
 
   end
@@ -131,22 +131,22 @@ describe Guard::Zeus::Runner do
   describe '.run' do
     context 'with Bundler' do
       before do
-        subject.should_receive(:bundler?).and_return(true)
+        expect(subject).to receive(:bundler?).and_return(true)
       end
 
       it 'pushes path to zeus' do
-        subject.should_receive(:run_command).with('bundle exec zeus test abacus', '')
+        expect(subject).to receive(:run_command).with('bundle exec zeus test abacus', '')
         subject.run(['abacus'])
       end
     end
 
     context 'without Bundler' do
       before do
-        subject.should_receive(:bundler?).and_return(false)
+        expect(subject).to receive(:bundler?).and_return(false)
       end
 
       it 'pushes path to zeus' do
-        subject.should_receive(:run_command).with('zeus test abacus', '')
+        expect(subject).to receive(:run_command).with('zeus test abacus', '')
         subject.run(['abacus'])
       end
     end
@@ -155,32 +155,32 @@ describe Guard::Zeus::Runner do
   describe '.run_all' do
     context 'with rspec' do
       it "calls Runner.run with 'spec'" do
-        subject.stub(:rspec?).and_return(true)
-        subject.stub(:test_unit?).and_return(false)
-        subject.should_receive(:run).with(['rspec'])
+        allow(subject).to receive(:rspec?).and_return(true)
+        allow(subject).to receive(:test_unit?).and_return(false)
+        expect(subject).to receive(:run).with(['rspec'])
         subject.run_all
       end
     end
 
     context 'with test_unit' do
       before do
-        Dir.should_receive(:[]).with('test/**/*_test.rb').once.and_return(%w{test/unit/foo_test.rb test/functional/bar_test.rb})
-        Dir.should_receive(:[]).with('test/**/test_*.rb').once.and_return(['test/unit/test_baz.rb'])
+        expect(Dir).to receive(:[]).with('test/**/*_test.rb').once.and_return(%w{test/unit/foo_test.rb test/functional/bar_test.rb})
+        expect(Dir).to receive(:[]).with('test/**/test_*.rb').once.and_return(['test/unit/test_baz.rb'])
       end
       
       it "calls Runner.run with each test file" do
-        subject.stub(:rspec?).and_return(false)
-        subject.stub(:test_unit?).and_return(true)
-        subject.should_receive(:run).with(%w{test/unit/foo_test.rb test/functional/bar_test.rb test/unit/test_baz.rb})
+        allow(subject).to receive(:rspec?).and_return(false)
+        allow(subject).to receive(:test_unit?).and_return(true)
+        expect(subject).to receive(:run).with(%w{test/unit/foo_test.rb test/functional/bar_test.rb test/unit/test_baz.rb})
         subject.run_all
       end
     end
 
     context 'with neither' do
       it 'not call Runner.run' do
-        subject.stub(:rspec?).and_return(false)
-        subject.stub(:test_unit?).and_return(false)
-        subject.should_not_receive(:run)
+        allow(subject).to receive(:rspec?).and_return(false)
+        allow(subject).to receive(:test_unit?).and_return(false)
+        expect(subject).not_to receive(:run)
         subject.run_all
       end
     end
@@ -188,8 +188,8 @@ describe Guard::Zeus::Runner do
     context 'with :run_all set to false' do
       let(:runner) { Guard::Zeus::Runner.new :run_all => false }
       it 'not run all specs' do
-        runner.stub(:rspec?).and_return(true)
-        runner.should_not_receive(:run)
+        allow(runner).to receive(:rspec?).and_return(true)
+        expect(runner).not_to receive(:run)
         runner.run_all
       end
     end
@@ -197,7 +197,7 @@ describe Guard::Zeus::Runner do
 
   describe '.bundler?' do
     before do
-      Dir.stub(:pwd).and_return("")
+      allow(Dir).to receive(:pwd).and_return("")
     end
 
     context 'with no bundler option' do
@@ -205,21 +205,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(true)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:bundler?).should be_true
+          expect(subject.send(:bundler?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(false)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
     end
@@ -229,21 +229,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
     end
@@ -253,21 +253,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(true)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:bundler?).should be_true
+          expect(subject.send(:bundler?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(false)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
     end
@@ -275,7 +275,7 @@ describe Guard::Zeus::Runner do
 
   describe '.test_unit?' do
     before do
-      Dir.stub(:pwd).and_return("")
+      allow(Dir).to receive(:pwd).and_return("")
     end
 
     context 'with no test_unit option' do
@@ -283,21 +283,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(true)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:test_unit?).should be_true
+          expect(subject.send(:test_unit?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(false)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
     end
@@ -307,21 +307,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
     end
@@ -331,21 +331,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(true)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:test_unit?).should be_true
+          expect(subject.send(:test_unit?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(false)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
     end
@@ -353,7 +353,7 @@ describe Guard::Zeus::Runner do
 
   describe '.rspec?' do
     before do
-      Dir.stub(:pwd).and_return("")
+      allow(Dir).to receive(:pwd).and_return("")
     end
 
     context 'with no rspec option' do
@@ -361,21 +361,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(true)
+          expect(File).to receive(:exist?).with('/spec').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:rspec?).should be_true
+          expect(subject.send(:rspec?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(false)
+          expect(File).to receive(:exist?).with('/spec').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
     end
@@ -385,21 +385,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
     end
@@ -409,21 +409,21 @@ describe Guard::Zeus::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(true)
+          expect(File).to receive(:exist?).with('/spec').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:rspec?).should be_true
+          expect(subject.send(:rspec?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(false)
+          expect(File).to receive(:exist?).with('/spec').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
     end

--- a/spec/guard/zeus_spec.rb
+++ b/spec/guard/zeus_spec.rb
@@ -4,49 +4,49 @@ describe Guard::Zeus do
 
   describe '#initialize' do
     it "instantiates Runner with given options" do
-      Guard::Zeus::Runner.should_receive(:new).with(:bundler => false)
+      expect(Guard::Zeus::Runner).to receive(:new).with(:bundler => false)
       Guard::Zeus.new :bundler => false
     end
   end
 
   describe '.start' do
     it "calls Runner.kill_zeus and Runner.launch_zeus with 'Start'" do
-      subject.runner.should_receive(:kill_zeus)
-      subject.runner.should_receive(:launch_zeus).with('Start')
+      expect(subject.runner).to receive(:kill_zeus)
+      expect(subject.runner).to receive(:launch_zeus).with('Start')
       subject.start
     end
   end
 
   describe '.reload' do
     it "calls Runner.kill_zeus and Runner.launch_zeus with 'Reload'" do
-      subject.runner.should_receive(:kill_zeus)
-      subject.runner.should_receive(:launch_zeus).with('Reload')
+      expect(subject.runner).to receive(:kill_zeus)
+      expect(subject.runner).to receive(:launch_zeus).with('Reload')
       subject.reload
     end
   end
 
   describe '.run_all' do
     it "calls Runner.run_all" do
-      subject.runner.should_receive(:run_all)
+      expect(subject.runner).to receive(:run_all)
       subject.run_all
     end
   end
 
   describe '.run_on_modifications' do
     it "calls Runner.run with file name" do
-      subject.runner.should_receive(:run).with('file_name.rb')
+      expect(subject.runner).to receive(:run).with('file_name.rb')
       subject.run_on_modifications('file_name.rb')
     end
 
     it "calls Runner.run with paths" do
-      subject.runner.should_receive(:run).with(['spec/controllers', 'spec/requests'])
+      expect(subject.runner).to receive(:run).with(['spec/controllers', 'spec/requests'])
       subject.run_on_modifications(['spec/controllers', 'spec/requests'])
     end
   end
 
   describe '.stop' do
     it 'calls Runner.kill_zeus' do
-      subject.runner.should_receive(:kill_zeus)
+      expect(subject.runner).to receive(:kill_zeus)
       subject.stop
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,4 @@ ENV['GUARD_ENV'] = 'test'
 RSpec.configure do |config|
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 end


### PR DESCRIPTION
Used [transpec](https://github.com/yujinakayama/transpec) to convert the rspec syntax from 2 to 3.

It worked well, the only flaw being that `subject.stub(test_unit?: false, rspec?: true, bundler?: false)` could not be converted automatically. I opted to split this into three seperate `allow` statements.
