### PR TITLE
invoke RSpec with "spec" dir [fix #16]

### DIFF
--- a/lib/guard/zeus/runner.rb
+++ b/lib/guard/zeus/runner.rb
@@ -47,7 +47,7 @@ module Guard
       def run_all
         return unless options[:run_all]
         if rspec?
-          run(['rspec'])
+          run(['spec'])
         elsif test_unit?
           run(Dir['test/**/*_test.rb'] + Dir['test/**/test_*.rb'])
         end

--- a/spec/guard/zeus/runner_spec.rb
+++ b/spec/guard/zeus/runner_spec.rb
@@ -202,10 +202,10 @@ RSpec.describe Guard::Zeus::Runner do
 
   describe '.run_all' do
     context 'with rspec' do
-      it "calls Runner.run with 'spec'" do
+      it "calls Runner.run with 'spec' directory" do
         allow(subject).to receive(:rspec?).and_return(true)
         allow(subject).to receive(:test_unit?).and_return(false)
-        expect(subject).to receive(:run).with(['rspec'])
+        expect(subject).to receive(:run).with(['spec'])
         subject.run_all
       end
     end


### PR DESCRIPTION
rspec is incorrectly called with 'rspec' dir, while
the typical spec dir is 'spec'